### PR TITLE
Only reuse plot info when a plot was resized

### DIFF
--- a/src/jaspModuleRegistration.h
+++ b/src/jaspModuleRegistration.h
@@ -70,6 +70,7 @@ RCPP_MODULE(jaspResults)
 		.property("plotObject",		&jaspPlot_Interface::getPlotObject,		&jaspPlot_Interface::setPlotObject,		"Stores the plotObj used to generate the graphic, will (should) be stored in a way that is later accesible to saveImage an editImage.")
 
 		.property("editing",		&jaspPlot_Interface::getEditing,		&jaspPlot_Interface::setEditing,		"If set to true will overwrite current png file when rendering a plot.")
+		.property("resizedByUser",	&jaspPlot_Interface::getResizedByUser,	&jaspPlot_Interface::setResizedByUser,	"If set to true, a user resized the plot and its width and height may be recycled in future runs of this analysis.")
 		.property("revision",		&jaspPlot_Interface::getRevision,												"return the current revision of the plot.")
 	;
 

--- a/src/jaspPlot.cpp
+++ b/src/jaspPlot.cpp
@@ -182,12 +182,15 @@ Rcpp::List jaspPlot::getOldPlotInfo(Rcpp::List & plotInfo)
 		jaspPrint("could not find an old plot");
 		return Rcpp::List();
 	}
-	jaspPrint("found a " + oldPlot->type() + " with name: " + oldPlot->_name);
+	jaspPrint("found a " + oldPlot->type() + " with name: " + oldPlot->_name + ". Modified by user: " + (oldPlot->_userResized ? "yes" : "no"));
 
-	_width				= oldPlot->_width;
-	_height				= oldPlot->_height;
-	plotInfo["width"]	= _width;
-	plotInfo["height"]	= _height;
+	if (!oldPlot->_userResized)
+	{
+		_width				= oldPlot->_width;
+		_height				= oldPlot->_height;
+		plotInfo["width"]	= _width;
+		plotInfo["height"]	= _height;
+	}
 
 	if (oldPlot->_editOptions == Json::nullValue)
 		return Rcpp::List();

--- a/src/jaspPlot.cpp
+++ b/src/jaspPlot.cpp
@@ -182,9 +182,9 @@ Rcpp::List jaspPlot::getOldPlotInfo(Rcpp::List & plotInfo)
 		jaspPrint("could not find an old plot");
 		return Rcpp::List();
 	}
-	jaspPrint("found a " + oldPlot->type() + " with name: " + oldPlot->_name + ". Modified by user: " + (oldPlot->_userResized ? "yes" : "no"));
+	jaspPrint("found a " + oldPlot->type() + " with name: " + oldPlot->_name + ". Resized by user: " + (oldPlot->_resizedByUser ? "yes" : "no"));
 
-	if (!oldPlot->_userResized)
+	if (oldPlot->_resizedByUser)
 	{
 		_width				= oldPlot->_width;
 		_height				= oldPlot->_height;
@@ -214,6 +214,7 @@ Json::Value jaspPlot::convertToJSON() const
 	obj["revision"]				= _revision;
 	obj["environmentName"]		= _envName;
 	obj["editOptions"]			= _editOptions;
+	obj["resizedByUser"]		= _resizedByUser;
 
 	return obj;
 }
@@ -230,6 +231,7 @@ void jaspPlot::convertFromJSON_SetFields(Json::Value in)
 	_filePathPng	= in.get("filePathPng",		"null").asString();
 	_envName		= in.get("environmentName",	_envName).asString();
 	_editOptions	= in.get("editOptions",		Json::nullValue);
+	_resizedByUser	= in.get("resizedByUser",	false).asBool();
 	
 	setUserPlotChangesFromRStateObject();
 	

--- a/src/jaspPlot.h
+++ b/src/jaspPlot.h
@@ -13,7 +13,7 @@ public:
 				_height,
 				_revision = 0;
 	bool		_editing = false,
-				_userResized = false;
+				_resizedByUser = false;
 	std::string	_filePathPng,
 				_status = "waiting",
 				_envName;
@@ -66,7 +66,7 @@ public:
 	JASPOBJECT_INTERFACE_PROPERTY_FUNCTIONS_GENERATOR(jaspPlot, int,			_revision,		Revision)
 
 	JASPOBJECT_INTERFACE_PROPERTY_FUNCTIONS_GENERATOR_NO_NOTIFY(jaspPlot, bool,	_editing,		Editing)
-	JASPOBJECT_INTERFACE_PROPERTY_FUNCTIONS_GENERATOR_NO_NOTIFY(jaspPlot, bool,	_userResized,	UserResized)
+	JASPOBJECT_INTERFACE_PROPERTY_FUNCTIONS_GENERATOR_NO_NOTIFY(jaspPlot, bool,	_resizedByUser,	ResizedByUser)
 };
 
 RCPP_EXPOSED_CLASS_NODECL(jaspPlot_Interface)

--- a/src/jaspPlot.h
+++ b/src/jaspPlot.h
@@ -12,7 +12,8 @@ public:
 	int			_width,
 				_height,
 				_revision = 0;
-	bool		_editing = false;
+	bool		_editing = false,
+				_userResized = false;
 	std::string	_filePathPng,
 				_status = "waiting",
 				_envName;
@@ -65,6 +66,7 @@ public:
 	JASPOBJECT_INTERFACE_PROPERTY_FUNCTIONS_GENERATOR(jaspPlot, int,			_revision,		Revision)
 
 	JASPOBJECT_INTERFACE_PROPERTY_FUNCTIONS_GENERATOR_NO_NOTIFY(jaspPlot, bool,	_editing,		Editing)
+	JASPOBJECT_INTERFACE_PROPERTY_FUNCTIONS_GENERATOR_NO_NOTIFY(jaspPlot, bool,	_userResized,	UserResized)
 };
 
 RCPP_EXPOSED_CLASS_NODECL(jaspPlot_Interface)


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1386
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1391

Requires https://github.com/jasp-stats/jaspBase/pull/43

This PR ensures that we only reuse plot information when a user resized a plot. This can still lead to unreadable plots (resize and then tick an option that would normally make a plot larger), but if it does go wrong, the user can fix the problem by resizing (and they resized before, so hopefully they'll remember how to do it again).

@JorisGoosen should I also bump `JASP_R_INTERFACE_MINOR_VERSION`?