### PR TITLE
This fixes the output on windows

### DIFF
--- a/src/jaspContainer.cpp
+++ b/src/jaspContainer.cpp
@@ -59,7 +59,7 @@ jaspContainer * jaspContainer::jaspContainerFromRcppList(Rcpp::List convertThis)
 
 	for(int i=0; i<convertThis.size(); i++)
 		if(colNamesVec[i] == "title")
-			newContainer->_title = Rcpp::as<std::string>(convertThis[i]);
+			newContainer->_title = jaspNativeToUtf8(Rcpp::RObject(convertThis[i]));
 		else
 			newContainer->insert(colNamesVec[i], convertThis[i]);
 
@@ -281,7 +281,7 @@ Json::Value jaspContainer::dataEntry(jaspObject * oldResult, std::string & error
 	std::string cascadingMsg		= cascaded ? errorMsg : _errorMessage;	//cascading errorMessagues trumps local one
 	jaspContainer * oldContainer	= dynamic_cast<jaspContainer*>(oldResult);		//dynamic_cast returns nullptr if not right type
 
-	for(std::string field: getSortedDataFieldsWithOld(oldContainer))
+	for(const std::string & field: getSortedDataFieldsWithOld(oldContainer))
 	{
 		jaspObject *	obj			= getJaspObjectNewOrOld(field, oldContainer);
 		bool			objIsOld	= jaspObjectComesFromOldResults(field, oldContainer);
@@ -466,9 +466,9 @@ void jaspContainer::setError()
 		d.second->setError();
 }
 
-void jaspContainer::setError(std::string message)
+void jaspContainer::setError(Rcpp::String message)
 {
-	_errorMessage = message;
+	_errorMessage = jaspNativeToUtf8(message);
 	setError();
 }
 

--- a/src/jaspContainer.h
+++ b/src/jaspContainer.h
@@ -14,7 +14,7 @@
 class jaspContainer : public jaspObject
 {
 public:
-	jaspContainer(std::string title = "", jaspObjectType type = jaspObjectType::container) : jaspObject(type, title)
+	jaspContainer(Rcpp::String title = "", jaspObjectType type = jaspObjectType::container) : jaspObject(type, title)
 	{
 #ifdef JASP_RESULTS_DEBUG_TRACES
 		std::cout << "JASPcontainer constructor for title: " << title << std::endl;
@@ -47,7 +47,7 @@ public:
 	void		completeChildren();
 	void		letChildrenRun();
 	void		setError()															override;
-	void		setError(std::string message)										override;
+	void		setError(Rcpp::String message)										override;
 	void		renderPlotsOfChildren();
 
 	bool		containsNonContainer();

--- a/src/jaspHtml.h
+++ b/src/jaspHtml.h
@@ -4,7 +4,7 @@
 class jaspHtml : public jaspObject
 {
 public:
-  jaspHtml(std::string text = "", std::string elementType = "p", std::string maxWidth="15cm", std::string Class = "") : jaspObject(jaspObjectType::html, ""), _rawText(text), _elementType(elementType), _class(Class), _maxWidth(maxWidth) {}
+  jaspHtml(Rcpp::String text = "", std::string elementType = "p", std::string maxWidth="15cm", std::string Class = "") : jaspObject(jaspObjectType::html, ""), _rawText(jaspNativeToUtf8(text)), _elementType(elementType), _class(Class), _maxWidth(maxWidth) {}
 
 	~jaspHtml() {}
 
@@ -33,9 +33,9 @@ class jaspHtml_Interface : public jaspObject_Interface
 public:
 	jaspHtml_Interface(jaspObject * dataObj) : jaspObject_Interface(dataObj) {}
 
-    void 		setText(std::string newRawText) { 			static_cast<jaspHtml *>(myJaspObject)->setText(newRawText); }
-    std::string getText() 						{ return 	static_cast<jaspHtml *>(myJaspObject)->getText(); }
-    std::string getHtml()						{ return	static_cast<jaspHtml *>(myJaspObject)->getHtml(); }
+    void			setText(Rcpp::String newRawText) { 			static_cast<jaspHtml *>(myJaspObject)->setText(jaspNativeToUtf8(newRawText)); }
+    Rcpp::String	getText() 						{ return 	static_cast<jaspHtml *>(myJaspObject)->getText(); }
+    std::string		getHtml()						{ return	static_cast<jaspHtml *>(myJaspObject)->getHtml(); }
 
 	JASPOBJECT_INTERFACE_PROPERTY_FUNCTIONS_GENERATOR(jaspHtml, std::string,	_elementType,	ElementType)
 	JASPOBJECT_INTERFACE_PROPERTY_FUNCTIONS_GENERATOR(jaspHtml, std::string,	_class,			Class)

--- a/src/jaspJson.h
+++ b/src/jaspJson.h
@@ -121,17 +121,8 @@ template<> inline Json::Value jaspJson::RMatrixColumnEntry_to_JsonValue<INTSXP>(
 template<> inline Json::Value jaspJson::RVectorEntry_to_JsonValue<LGLSXP>(Rcpp::Vector<LGLSXP> obj, int row)					{ return obj[row] == NA_LOGICAL	? "" : Json::Value((bool)(obj[row]));			}
 template<> inline Json::Value jaspJson::RMatrixColumnEntry_to_JsonValue<LGLSXP>(Rcpp::MatrixColumn<LGLSXP> obj, int row)		{ return obj[row] == NA_LOGICAL	? "" : Json::Value((bool)(obj[row]));			}
 
-template<> inline Json::Value jaspJson::RVectorEntry_to_JsonValue<STRSXP>(Rcpp::Vector<STRSXP> obj, int row)					
-{ 
-	Rcpp::String input(obj[row]);	
-	
-	//jaspPrint("jaspJson from string got " + std::string(input.get_cstring()) + " and it has encoding " + (input.get_encoding() == CE_UTF8 ? "UTF8" : "something else") );
-	
-	return obj[row] == NA_STRING	? "" : Json::Value(stringUtils::escapeHtmlStuff((std::string)(obj[row])));
-
-
-}
-template<> inline Json::Value jaspJson::RMatrixColumnEntry_to_JsonValue<STRSXP>(Rcpp::MatrixColumn<STRSXP> obj, int row)		{ return obj[row] == NA_STRING	? "" : Json::Value(stringUtils::escapeHtmlStuff((std::string)(obj[row])));	}
+template<> inline Json::Value jaspJson::RVectorEntry_to_JsonValue<STRSXP>(Rcpp::Vector<STRSXP> obj, int row)					{ return obj[row] == NA_STRING	? "" : Json::Value(stringUtils::escapeHtmlStuff(jaspNativeToUtf8(obj[row])));	}
+template<> inline Json::Value jaspJson::RMatrixColumnEntry_to_JsonValue<STRSXP>(Rcpp::MatrixColumn<STRSXP> obj, int row)		{ return obj[row] == NA_STRING	? "" : Json::Value(stringUtils::escapeHtmlStuff(jaspNativeToUtf8(obj[row])));	}
 
 #define TO_INFINITY_AND_BEYOND																					\
 {																												\

--- a/src/jaspObject.cpp
+++ b/src/jaspObject.cpp
@@ -55,6 +55,27 @@ void jaspPrint(std::string msg)
 #endif
 }
 
+std::string jaspNativeToUtf8(const Rcpp::RObject &in)
+{
+	if(in.isNULL())
+		return "";
+	
+	return jaspNativeToUtf8(Rcpp::as<Rcpp::String>(in));
+}
+
+
+std::string jaspNativeToUtf8(const Rcpp::String & in)
+{
+#ifdef _WIN32
+	#ifdef JASP_R_INTERFACE_LIBRARY
+		return jaspRCPP_nativeToUtf8(in);
+	#else
+		return in; //If running in R then it's the users problem really.
+	#endif	
+#else
+	return in;
+#endif
+}
 
 std::set<jaspObject*> * jaspObject::allocatedObjects = new std::set<jaspObject*>();
 
@@ -195,7 +216,7 @@ Rcpp::DataFrame jaspObject::convertFactorsToCharacters(Rcpp::DataFrame df)
 
 			for(int i=0; i<originalColumn.size(); i++)
 				if(originalColumn[i] > 0) //it can be INT_MIN at least, but if we are doing a -1 on it anyhow it should just be bigger than 0
-					charCol[i] = Rcpp::as<std::string>(factorLevels[originalColumn[i] - 1]);
+					charCol[i] = jaspNativeToUtf8(factorLevels[originalColumn[i] - 1]);
 
 			df[col] = charCol;
 		}

--- a/src/jaspPlot.cpp
+++ b/src/jaspPlot.cpp
@@ -107,13 +107,13 @@ void jaspPlot::renderPlot()
 			plotInfo["obj"] = writeResult["obj"];
 
 		if(writeResult.containsElementNamed("png"))
-			_filePathPng = Rcpp::as<std::string>(writeResult["png"]);
+			_filePathPng = jaspNativeToUtf8(Rcpp::as<Rcpp::String>(writeResult["png"]));
 
 		_editOptions = Json::nullValue;
 
 		if(writeResult.containsElementNamed("editOptions") && !Rf_isNull(writeResult["editOptions"]))
 		{
-			std::string editOptionsStr = Rcpp::as<std::string>(writeResult["editOptions"]);
+			std::string editOptionsStr = jaspNativeToUtf8(Rcpp::as<Rcpp::String>(writeResult["editOptions"]));
 
 			if(editOptionsStr != "")
 			{
@@ -125,7 +125,7 @@ void jaspPlot::renderPlot()
 		if(writeResult.containsElementNamed("error"))
 		{
 			_error			= true;
-			_errorMessage	= Rcpp::as<std::string>(writeResult["error"]);
+			_errorMessage	= jaspNativeToUtf8(Rcpp::as<Rcpp::String>(writeResult["error"]));
 		}
 		else
 		{

--- a/src/jaspPlot.h
+++ b/src/jaspPlot.h
@@ -4,7 +4,7 @@
 class jaspPlot : public jaspObject
 {
 public:
-	jaspPlot(std::string title = "") : jaspObject(jaspObjectType::plot, title) { initEnvName(); }
+	jaspPlot(Rcpp::String title = "") : jaspObject(jaspObjectType::plot, title) { initEnvName(); }
 
 	~jaspPlot();
 

--- a/src/jaspResults.cpp
+++ b/src/jaspResults.cpp
@@ -68,7 +68,7 @@ void jaspResults::setInsideJASP()
 	_insideJASP = true;
 }
 
-jaspResults::jaspResults(std::string title, Rcpp::RObject oldState)
+jaspResults::jaspResults(Rcpp::String title, Rcpp::RObject oldState)
 	: jaspContainer(title, jaspObjectType::results)
 {
 	_jaspResults = this;
@@ -389,9 +389,9 @@ Json::Value jaspResults::dataEntry(std::string &) const
 
 
 
-void jaspResults::setErrorMessage(std::string msg, std::string errorStatus)
+void jaspResults::setErrorMessage(Rcpp::String msg, std::string errorStatus)
 {
-	errorMessage = msg;
+	errorMessage = jaspNativeToUtf8(msg);
 	setStatus(errorStatus);
 }
 
@@ -534,7 +534,7 @@ void jaspResults::convertFromJSON_SetFields(Json::Value in)
 
 
 
-void jaspResults::startProgressbar(int expectedTicks, std::string label)
+void jaspResults::startProgressbar(int expectedTicks, Rcpp::String label)
 {
 	_progressbarExpectedTicks		= expectedTicks;
 	_progressbarLastUpdateTime		= getCurrentTimeMs();
@@ -542,7 +542,7 @@ void jaspResults::startProgressbar(int expectedTicks, std::string label)
 
 	Json::Value progress;
 	progress["value"]		= 0;
-	progress["label"]		= label;
+	progress["label"]		= jaspNativeToUtf8(label);
 	_response["progress"]	= progress;
 
 	send();

--- a/src/jaspResults.h
+++ b/src/jaspResults.h
@@ -21,7 +21,7 @@ typedef bool (*pollMessagesFuncDef)();
 class jaspResults : public jaspContainer
 {
 public:
-	jaspResults(std::string title, Rcpp::RObject oldState);
+	jaspResults(Rcpp::String title, Rcpp::RObject oldState);
 	~jaspResults();
 
 	//static functions to allow the values to be set before the constructor is called from R. Would be nicer to just run the constructor in C++ maybe?
@@ -56,7 +56,7 @@ public:
 	void			saveResults();
 
 	void			loadResults();
-	void			setErrorMessage(std::string msg, std::string errorStatus);
+	void			setErrorMessage(Rcpp::String msg, std::string errorStatus);
 	void			changeOptions(std::string opts);
 	void			setOptions(std::string opts);
 	void			pruneInvalidatedData();
@@ -73,10 +73,10 @@ public:
 	void		convertFromJSON_SetFields(Json::Value in)			override;
 
 
-	void startProgressbar(int expectedTicks, std::string label);
+	void startProgressbar(int expectedTicks, Rcpp::String label);
 	void progressbarTick();
 
-	static void staticStartProgressbar(int expectedTicks, std::string label)			{ _jaspResults->startProgressbar(expectedTicks, label); }
+	static void staticStartProgressbar(int expectedTicks, Rcpp::String label)			{ _jaspResults->startProgressbar(expectedTicks, label); }
 	static void staticProgressbarTick()													{ _jaspResults->progressbarTick(); }
 
 	static Rcpp::RObject	getObjectFromEnv(std::string envName);
@@ -120,9 +120,9 @@ private:
 
 	jaspContainer					*	_oldResults	= nullptr;
 
-	void addSerializedPlotObjsForStateFromJaspObject(jaspObject * obj, Rcpp::List & pngImgObj);
-	void addPlotPathsForKeepFromJaspObject(jaspObject * obj, Rcpp::List & pngPathImgObj);
-	void addSerializedOtherObjsForStateFromJaspObject(jaspObject * obj, Rcpp::List & cumulativeList);
+	void addSerializedPlotObjsForStateFromJaspObject(	jaspObject * obj, Rcpp::List & pngImgObj);
+	void addPlotPathsForKeepFromJaspObject(				jaspObject * obj, Rcpp::List & pngPathImgObj);
+	void addSerializedOtherObjsForStateFromJaspObject(	jaspObject * obj, Rcpp::List & cumulativeList);
 	void fillEnvironmentWithStateObjects(Rcpp::List state);
 	void storeOldResults();
 
@@ -160,7 +160,7 @@ public:
 	Rcpp::List	getKeepList()						{ return ((jaspResults*)myJaspObject)->getKeepList();				}
 	std::string getResults()						{ return ((jaspResults*)myJaspObject)->getResults();				}
 	
-	void		setErrorMessage(std::string msg, std::string errorStatus)			{ ((jaspResults*)myJaspObject)->setErrorMessage(msg, errorStatus);							}
+	void		setErrorMessage(Rcpp::String msg, std::string errorStatus)			{ ((jaspResults*)myJaspObject)->setErrorMessage(msg, errorStatus);							}
 
 	void		setOptions(std::string opts)		{ ((jaspResults*)myJaspObject)->setOptions(opts); }
 	void		changeOptions(std::string opts)		{ ((jaspResults*)myJaspObject)->changeOptions(opts); }

--- a/src/jaspTable.h
+++ b/src/jaspTable.h
@@ -79,7 +79,7 @@ using footnotesNamespace::footnotes;
 class jaspTable : public jaspObject
 {
 public:
-	jaspTable(std::string title = "") : jaspObject(jaspObjectType::table, title), _colNames("colNames"), _colTypes("colTypes"), _colTitles("colTitles"), _colOvertitles("colOvertitles"), _colFormats("colFormats"), _rowNames("rowNames"), _rowTitles("rowTitles") {}
+	jaspTable(Rcpp::String title = "") : jaspObject(jaspObjectType::table, title), _colNames("colNames"), _colTypes("colTypes"), _colTitles("colTitles"), _colOvertitles("colOvertitles"), _colFormats("colFormats"), _rowNames("rowNames"), _rowTitles("rowTitles") {}
 
 	void			setColNames(Rcpp::List newNames)		{ _colNames.setRows(newNames); }
 	jaspStringlist	_colNames;
@@ -427,11 +427,11 @@ public:
 	//void combineColumns(Rcpp::map_named_args named_args)			{ ((jaspTable*)myJaspObject)->combineColumns(named_args);	}
 	//void combineRows(Rcpp::map_named_args named_args)				{ ((jaspTable*)myJaspObject)->combineRows(named_args);		}
 
-	void addRows(Rcpp::RObject newRows, Rcpp::CharacterVector rowNames)	{ ((jaspTable*)myJaspObject)->addRows(newRows, rowNames);		}
-	void addRowsWithoutNames(Rcpp::RObject newRows)						{ ((jaspTable*)myJaspObject)->addRowsWithoutNames(newRows);		}
-	void addRow(Rcpp::RObject newRow, Rcpp::CharacterVector rowNames)	{ ((jaspTable*)myJaspObject)->addRow(newRow, rowNames);		}
-	void addRowWithoutNames(Rcpp::RObject newRow)						{ ((jaspTable*)myJaspObject)->addRowWithoutNames(newRow);		}
-	void setColumn(std::string columnName, Rcpp::RObject column)		{ ((jaspTable*)myJaspObject)->setColumn(columnName, column);	}
+	void addRows(				Rcpp::RObject newRows,	Rcpp::CharacterVector rowNames)	{ ((jaspTable*)myJaspObject)->addRows(newRows, rowNames);		}
+	void addRowsWithoutNames(	Rcpp::RObject newRows)									{ ((jaspTable*)myJaspObject)->addRowsWithoutNames(newRows);		}
+	void addRow(				Rcpp::RObject newRow,	Rcpp::CharacterVector rowNames)	{ ((jaspTable*)myJaspObject)->addRow(newRow, rowNames);			}
+	void addRowWithoutNames(	Rcpp::RObject newRow)									{ ((jaspTable*)myJaspObject)->addRowWithoutNames(newRow);		}
+	void setColumn(				std::string columnName, Rcpp::RObject column)			{ ((jaspTable*)myJaspObject)->setColumn(columnName, column);	}
 
 	void setExpectedSize(size_t columns, size_t rows)	{ ((jaspTable*)myJaspObject)->setExpectedSize(columns, rows);	}
 	void setExpectedRows(size_t rows)					{ ((jaspTable*)myJaspObject)->setExpectedRows(rows);			}


### PR DESCRIPTION
Part of the fix for https://github.com/jasp-stats/jasp-issues/issues/1350

the added `jaspNativeToUtf8` function makes sure that whenever we are running JASP (and thus R-Interface) we always first check the  encoding of the strings that are userfacing (and some filepaths) and then jumps through some hoops to get it to utf-8.

This all should only be done in windows of course. The actual function doing this is in jasp-desktop though.