### PR TITLE
Make sure jaspQmlSource only sends huge json at the end

### DIFF
--- a/src/jaspContainer.cpp
+++ b/src/jaspContainer.cpp
@@ -365,6 +365,10 @@ void jaspContainer::completeChildren()
 			static_cast<jaspPlot*>(obj)->complete();
 			break;
 
+		case jaspObjectType::qmlSource:
+			static_cast<jaspQmlSource*>(obj)->complete();
+			break;
+
 		default:
 			break;
 		}

--- a/src/jaspQmlSource.cpp
+++ b/src/jaspQmlSource.cpp
@@ -7,7 +7,7 @@ jaspQmlSource::jaspQmlSource(const std::string & sourceID) : jaspJson(), _source
 
 Json::Value jaspQmlSource::dataEntry(std::string & errorMessage) const
 {
-	Json::Value dataJson(jaspJson::dataEntry(errorMessage));
+	Json::Value dataJson(_complete ? jaspJson::dataEntry(errorMessage) : jaspObject::dataEntry(errorMessage));
 
 	dataJson["sourceID"] = _sourceID;
 

--- a/src/jaspQmlSource.h
+++ b/src/jaspQmlSource.h
@@ -17,7 +17,12 @@ public:
 	void		convertFromJSON_SetFields(Json::Value in)		override;
 	Json::Value convertToJSON()							const	override;
 
+	void		complete()	{ _complete = true; }
+
 	std::string		_sourceID;
+
+protected:
+	bool			_complete = false; ///<- This is used to keep the logfiles/resultjson small until the source is actually needed. Which is at complete only anyway
 };
 
 

--- a/src/jaspResults.cpp
+++ b/src/jaspResults.cpp
@@ -354,7 +354,7 @@ Json::Value jaspResults::metaEntry() const
 
 	std::vector<std::string> orderedDataFields = getSortedDataFieldsWithOld(_oldResults);
 
-	for(std::string field: orderedDataFields)
+	for(const std::string & field : orderedDataFields)
 	{
 		jaspObject *	obj			= getJaspObjectNewOrOld(field, _oldResults);
 		bool			objIsOld	= jaspObjectComesFromOldResults(field, _oldResults);
@@ -374,7 +374,7 @@ Json::Value jaspResults::dataEntry(std::string &) const
 	dataJson["name"]	= getUniqueNestedName();
 	dataJson[".meta"]	= metaEntry();
 
-	for(std::string field: getSortedDataFieldsWithOld(_oldResults))
+	for(const std::string & field: getSortedDataFieldsWithOld(_oldResults))
 	{
 		jaspObject *	obj			= getJaspObjectNewOrOld(field, _oldResults);
 		bool			objIsOld	= jaspObjectComesFromOldResults(field, _oldResults);


### PR DESCRIPTION
Because Desktop only looks at rSources when the analysis is complete there is no reason to constantly have it all be sent.
Especially with, for instance, Cochrane...

Implements https://github.com/jasp-stats/INTERNAL-jasp/issues/1691