### PR TITLE
Do not send a R source if its value did not change.

### DIFF
--- a/src/jaspContainer.cpp
+++ b/src/jaspContainer.cpp
@@ -261,7 +261,7 @@ Json::Value jaspContainer::metaEntry(jaspObject * oldResult) const
 		jaspObject *	obj			= getJaspObjectNewOrOld(field, oldContainer);
 		bool			objIsOld	= jaspObjectComesFromOldResults(field, oldContainer);
 
-		if(obj->shouldBePartOfResultsJson())
+		if(obj->shouldBePartOfResultsJson(true))
 			submeta.append(obj->metaEntry(objIsOld || !oldContainer ? nullptr : oldContainer->getJaspObjectFromData(field)));
 	}
 

--- a/src/jaspJson.h
+++ b/src/jaspJson.h
@@ -9,7 +9,7 @@ public:
 	jaspJson(Json::Value json = Json::nullValue)	: jaspObject(jaspObjectType::json, ""), _json(json) {}
 	jaspJson(Rcpp::RObject Robj)					: jaspObject(jaspObjectType::json, ""), _json(RObject_to_JsonValue(Robj)) {}
 
-	void		setValue(Rcpp::RObject Robj)	{ _json = RObject_to_JsonValue(Robj);	}
+	void		setValue(Rcpp::RObject Robj)	{ _json = RObject_to_JsonValue(Robj); _changed = true;	}
 	std::string	getValue()						{ return _json.toStyledString();		}
 
 	static Json::Value RObject_to_JsonValue(Rcpp::RObject		obj);
@@ -111,8 +111,11 @@ public:
 	Json::Value convertToJSON()								const	override;
 	void		convertFromJSON_SetFields(Json::Value in)			override;
 
+	bool		changed()									const			 { return _changed; }
+
 protected:
 	Json::Value _json;
+	bool		_changed = false;
 };
 
 template<> inline Json::Value jaspJson::RVectorEntry_to_JsonValue<INTSXP>(Rcpp::Vector<INTSXP> obj, int row)					{ return obj[row] == NA_INTEGER	? "" : Json::Value((int)(obj[row]));			}

--- a/src/jaspObject.h
+++ b/src/jaspObject.h
@@ -72,10 +72,10 @@ public:
 						_info;
 			int			_position = JASPOBJECT_DEFAULT_POSITION;
 
-			jaspObjectType	getType()						{ return _type; }
-			bool			shouldBePartOfResultsJson()		{ return _type != jaspObjectType::state && _type != jaspObjectType::json; }
+			jaspObjectType	getType()															const { return _type; }
+	virtual bool			shouldBePartOfResultsJson(bool meta = false)						const { return _type != jaspObjectType::state && _type != jaspObjectType::json; }
 
-			Json::Value		constructMetaEntry(std::string type, std::string meta = "") const;
+			Json::Value		constructMetaEntry(std::string type, std::string meta = "")			const;
 
 	//These functions convert the object to a json that can be understood by the resultsviewer
 	virtual	Json::Value		metaEntry()															const { return Json::Value(Json::nullValue); }

--- a/src/jaspQmlSource.cpp
+++ b/src/jaspQmlSource.cpp
@@ -28,3 +28,9 @@ Json::Value jaspQmlSource::convertToJSON() const
 
 	return obj;
 }
+
+bool jaspQmlSource::shouldBePartOfResultsJson(bool meta) const
+{
+	// If the source has not changed, send the meta part, but not the result
+	return jaspJson::shouldBePartOfResultsJson(meta) && (meta || changed());
+}

--- a/src/jaspQmlSource.h
+++ b/src/jaspQmlSource.h
@@ -8,16 +8,18 @@ class jaspQmlSource : public jaspJson
 public:
 					jaspQmlSource(const std::string & sourceID = "");
 
-	void			setSourceID(const std::string & sourceID)			{ _sourceID = sourceID; }
-	std::string		sourceID()									const	{ return _sourceID; }
+	void			setSourceID(const std::string & sourceID)						 { _sourceID = sourceID; }
+	std::string		sourceID()										const			 { return _sourceID; }
 
-	Json::Value	metaEntry()								const	override { return constructMetaEntry("qmlSource"); }
-	Json::Value	dataEntry(std::string & errorMessage)	const	override;
+	Json::Value		metaEntry()										const	override { return constructMetaEntry("qmlSource"); }
+	Json::Value		dataEntry(std::string & errorMessage)			const	override;
 
-	void		convertFromJSON_SetFields(Json::Value in)		override;
-	Json::Value convertToJSON()							const	override;
+	void			convertFromJSON_SetFields(Json::Value in)				override;
+	Json::Value		convertToJSON()									const	override;
 
-	void		complete()	{ _complete = true; }
+	bool			shouldBePartOfResultsJson(bool meta = false)	const	override;
+
+	void			complete()	{ _complete = true; }
 
 	std::string		_sourceID;
 

--- a/src/jaspResults.cpp
+++ b/src/jaspResults.cpp
@@ -359,7 +359,7 @@ Json::Value jaspResults::metaEntry() const
 		jaspObject *	obj			= getJaspObjectNewOrOld(field, _oldResults);
 		bool			objIsOld	= jaspObjectComesFromOldResults(field, _oldResults);
 
-		if(obj->shouldBePartOfResultsJson())
+		if(obj->shouldBePartOfResultsJson(true))
 			meta.append(obj->metaEntry(objIsOld || !_oldResults ? nullptr : _oldResults->getJaspObjectFromData(field)));
 	}
 


### PR DESCRIPTION
This has to be merged with https://github.com/jasp-stats/jasp-desktop/pull/4706
I have added a boolean to check whether a QML source has changed. It works now, but not sure if this the best way...