### PR TITLE
jaspQmlSource should not encode Html characters

### DIFF
--- a/src/jaspJson.cpp
+++ b/src/jaspJson.cpp
@@ -1,57 +1,7 @@
 #include "jaspJson.h"
 
-Json::Value jaspJson::RObject_to_JsonValue(Rcpp::RObject obj)
-{
-	if(obj.isNULL())								return Json::nullValue;
-	else if(Rcpp::is<Rcpp::List>(obj))				return RObject_to_JsonValue((Rcpp::List)					obj);
-	else if(Rcpp::is<Rcpp::DataFrame>(obj))			return RObject_to_JsonValue((Rcpp::List)					obj);
-	else if(Rcpp::is<Rcpp::NumericMatrix>(obj))		return RObject_to_JsonValue<REALSXP>((Rcpp::NumericMatrix)	obj);
-	else if(Rcpp::is<Rcpp::NumericVector>(obj))		return RObject_to_JsonValue<REALSXP>((Rcpp::NumericVector)	obj);
-	else if(Rcpp::is<Rcpp::IntegerVector>(obj))		return RObject_to_JsonValue<INTSXP>((Rcpp::IntegerVector)	obj);
-	else if(Rcpp::is<Rcpp::LogicalVector>(obj))		return RObject_to_JsonValue<LGLSXP>((Rcpp::LogicalVector)	obj);
-	else if(Rcpp::is<Rcpp::CharacterVector>(obj))	return RObject_to_JsonValue<STRSXP>((Rcpp::CharacterVector)	obj);
-	else if(Rcpp::is<Rcpp::StringVector>(obj))		return RObject_to_JsonValue<STRSXP>((Rcpp::StringVector)	obj);
-	else if(obj.isS4())								return "an S4, which is too complicated for jaspResults now.";
-	else											return "something that is not understood by jaspResults right now..";
-}
 
-Json::Value jaspJson::RObject_to_JsonValue(Rcpp::List obj)
-{
-	bool atLeastOneNamed = false;
-
-	Rcpp::RObject namesListRObject = obj.names();
-	Rcpp::CharacterVector namesList;
-
-	if(!namesListRObject.isNULL())
-	{
-		namesList = namesListRObject;
-
-		for(int row=0; row<obj.size(); row++)
-			if(namesList[row] != "")
-				atLeastOneNamed = true;
-	}
-
-	Json::Value val = atLeastOneNamed ? Json::objectValue : Json::arrayValue;
-
-	if(atLeastOneNamed)
-		for(int row=obj.size() - 1; row>=0; row--) //We go backwards because in R the first entry of a name in a list is used. So to emulate this we go backwars and we override an earlier occurence. (aka you have two elements with the name "a" in a list and in R list$a returns the first occurence. This is now also the element visible in the json.)
-		{
-			std::string name(namesList[row]);
-
-			if(name == "")
-				name = "element_" + std::to_string(row);
-
-			val[name] = RObject_to_JsonValue((Rcpp::RObject)obj[row]);
-		}
-	else
-		for(int row=0; row<obj.size(); row++)
-			val.append(RObject_to_JsonValue((Rcpp::RObject)obj[row]));
-
-
-	return val;
-}
-
-std::string jaspJson::jsonToPrefixedStrings(Json::Value val, std::string prefix)
+std::string jaspJson::jsonToPrefixedStrings(Json::Value val, std::string prefix) const
 {
 	if(prefix == "")
 		return val.toStyledString();
@@ -67,40 +17,6 @@ std::string jaspJson::jsonToPrefixedStrings(Json::Value val, std::string prefix)
 			out << letter << prefix;
 
 	return out.str();
-}
-
-Json::Value jaspJson::VectorJson_to_ArrayJson(std::vector<Json::Value> vec)
-{
-	Json::Value array(Json::arrayValue);
-	for(auto val: vec)
-		array.append(val);
-	return array;
-}
-
-Json::Value jaspJson::SetJson_to_ArrayJson(std::set<Json::Value> set)
-{
-	Json::Value array(Json::arrayValue);
-	for(auto val: set)
-		array.append(val);
-	return array;
-}
-
-std::set<Json::Value> jaspJson::ArrayJson_to_SetJson(Json::Value arr)
-{
-	std::set<Json::Value> set;
-	for(auto & val: arr)
-		set.insert(val);
-	return set;
-}
-
-std::vector<Json::Value> jaspJson::RList_to_VectorJson(Rcpp::List obj)
-{
-	std::vector<Json::Value> vec;
-
-	for(int row=0; row<obj.size(); row++)
-		vec.push_back(RObject_to_JsonValue((Rcpp::RObject)obj[row]));
-
-	return vec;
 }
 
 Json::Value jaspJson::dataEntry(std::string & errorMessage) const

--- a/src/jaspJson.h
+++ b/src/jaspJson.h
@@ -6,104 +6,20 @@
 class jaspJson : public jaspObject
 {
 public:
-	jaspJson(Json::Value json = Json::nullValue)	: jaspObject(jaspObjectType::json, ""), _json(json) {}
+	jaspJson(Json::Value json = Json::nullValue)	: jaspObject(jaspObjectType::json, ""), _json(json)	{}
 	jaspJson(Rcpp::RObject Robj)					: jaspObject(jaspObjectType::json, ""), _json(RObject_to_JsonValue(Robj)) {}
 
 	void		setValue(Rcpp::RObject Robj)	{ _json = RObject_to_JsonValue(Robj); _changed = true;	}
 	std::string	getValue()						{ return _json.toStyledString();		}
 
-	static Json::Value RObject_to_JsonValue(Rcpp::RObject		obj);
-	static Json::Value RObject_to_JsonValue(Rcpp::List 			obj);
-
-
-	template<int RTYPE>	static Json::Value RObject_to_JsonValue(Rcpp::Matrix<RTYPE>	obj)
-	{
-		Json::Value val(Json::arrayValue);
-
-		for(int col=0; col<obj.ncol(); col++)
-		{
-			Json::Value valCol(Json::arrayValue);
-
-			for(int row=0; row<obj.column(col).size(); row++)
-				valCol.append(RMatrixColumnEntry_to_JsonValue(obj.column(col), row));
-
-			val.append(valCol);
-		}
-
-		return val;
-	}
-
-	template<int RTYPE>	static Json::Value RObject_to_JsonValue(Rcpp::Vector<RTYPE>	obj)
-	{
-		Json::Value val("");
-
-		if(obj.size() == 1)
-			val = RVectorEntry_to_JsonValue(obj, 0);
-		else if(obj.size() > 1)
-		{
-			val = Json::Value(Json::arrayValue);
-
-			for(int row=0; row<obj.size(); row++)
-				val.append(RVectorEntry_to_JsonValue(obj, row));
-		}
-
-		return val;
-	}
-
-	template<int RTYPE> static inline Json::Value RVectorEntry_to_JsonValue(Rcpp::Vector<RTYPE> obj, int row)				{ return ""; }
-	template<int RTYPE> static inline Json::Value RMatrixColumnEntry_to_JsonValue(Rcpp::MatrixColumn<RTYPE> obj, int row)	{ return ""; }
 
 	std::string dataToString(std::string prefix) const override { return jsonToPrefixedStrings(prefix + "\t"); }
 
-			std::string jsonToPrefixedStrings(std::string prefix = "") const { return jsonToPrefixedStrings(_json, prefix); }
-	static	std::string jsonToPrefixedStrings(Json::Value val, std::string prefix);
+	std::string jsonToPrefixedStrings(std::string prefix = "") const { return jsonToPrefixedStrings(_json, prefix); }
+	std::string jsonToPrefixedStrings(Json::Value val, std::string prefix) const;
 
-	static Json::Value RcppVector_to_ArrayJson(Rcpp::RObject obj, bool throwError=true) { return VectorJson_to_ArrayJson(RcppVector_to_VectorJson(obj, throwError)); }
-	static Json::Value VectorJson_to_ArrayJson(std::vector<Json::Value> vec);
-	static Json::Value SetJson_to_ArrayJson(std::set<Json::Value> set);
-	static std::set<Json::Value> ArrayJson_to_SetJson(Json::Value arr);
-	static std::vector<Json::Value> RList_to_VectorJson(Rcpp::List obj);
+	 Json::Value RcppVector_to_ArrayJson(Rcpp::RObject obj, bool throwError=true) { return VectorJson_to_ArrayJson(RcppVector_to_VectorJson(obj, throwError)); }
 
-	static std::vector<Json::Value> RcppVector_to_VectorJson(Rcpp::RObject obj, bool throwError=false)
-	{
-		if(Rcpp::is<Rcpp::NumericVector>(obj))			return RcppVector_to_VectorJson<REALSXP>((Rcpp::NumericVector)		obj);
-		else if(Rcpp::is<Rcpp::LogicalVector>(obj))		return RcppVector_to_VectorJson<LGLSXP>((Rcpp::LogicalVector)		obj);
-		else if(Rcpp::is<Rcpp::IntegerVector>(obj))		return RcppVector_to_VectorJson<INTSXP>((Rcpp::IntegerVector)		obj);
-		else if(Rcpp::is<Rcpp::StringVector>(obj))		return RcppVector_to_VectorJson<STRSXP>((Rcpp::StringVector)		obj);
-		else if(Rcpp::is<Rcpp::CharacterVector>(obj))	return RcppVector_to_VectorJson<STRSXP>((Rcpp::CharacterVector)		obj);
-		else if(Rcpp::is<Rcpp::List>(obj))				return RList_to_VectorJson((Rcpp::List)								obj);
-		else if(throwError) Rf_error("JASPjson::RcppVector_to_VectorJson received an SEXP that is not a Vector of some kind.");
-
-		return std::vector<Json::Value>({""});
-	}
-
-
-	template<int RTYPE>	static std::vector<Json::Value> RcppVector_to_VectorJson(Rcpp::Vector<RTYPE> obj)
-	{
-		std::vector<Json::Value> vec;
-
-		for(int row=0; row<obj.size(); row++)
-			vec.push_back(RVectorEntry_to_JsonValue(obj, row));
-
-		return vec;
-	}
-
-	template<int RTYPE>	static std::vector<std::vector<Json::Value>> RcppMatrix_to_Vector2Json(Rcpp::Matrix<RTYPE>	obj)
-	{
-		std::vector<std::vector<Json::Value>> vecvec;
-
-		for(int col=0; col<obj.ncol(); col++)
-		{
-			std::vector<Json::Value> vec;
-
-			for(int row=0; row<obj.column(col).size(); row++)
-				vec.push_back(RMatrixColumnEntry_to_JsonValue(obj.column(col), row));
-
-			vecvec.push_back(vec);
-		}
-
-		return vecvec;
-	}
 
 	Json::Value	metaEntry()									const	override { return constructMetaEntry("json"); }
 	Json::Value	dataEntry(std::string & errorMessage)		const	override;
@@ -115,31 +31,8 @@ public:
 
 protected:
 	Json::Value _json;
-	bool		_changed = false;
+	bool		_changed	= false;
 };
-
-template<> inline Json::Value jaspJson::RVectorEntry_to_JsonValue<INTSXP>(Rcpp::Vector<INTSXP> obj, int row)					{ return obj[row] == NA_INTEGER	? "" : Json::Value((int)(obj[row]));			}
-template<> inline Json::Value jaspJson::RMatrixColumnEntry_to_JsonValue<INTSXP>(Rcpp::MatrixColumn<INTSXP> obj, int row)		{ return obj[row] == NA_INTEGER	? "" : Json::Value((int)(obj[row]));			}
-
-template<> inline Json::Value jaspJson::RVectorEntry_to_JsonValue<LGLSXP>(Rcpp::Vector<LGLSXP> obj, int row)					{ return obj[row] == NA_LOGICAL	? "" : Json::Value((bool)(obj[row]));			}
-template<> inline Json::Value jaspJson::RMatrixColumnEntry_to_JsonValue<LGLSXP>(Rcpp::MatrixColumn<LGLSXP> obj, int row)		{ return obj[row] == NA_LOGICAL	? "" : Json::Value((bool)(obj[row]));			}
-
-template<> inline Json::Value jaspJson::RVectorEntry_to_JsonValue<STRSXP>(Rcpp::Vector<STRSXP> obj, int row)					{ return obj[row] == NA_STRING	? "" : Json::Value(stringUtils::escapeHtmlStuff(jaspNativeToUtf8(obj[row])));	}
-template<> inline Json::Value jaspJson::RMatrixColumnEntry_to_JsonValue<STRSXP>(Rcpp::MatrixColumn<STRSXP> obj, int row)		{ return obj[row] == NA_STRING	? "" : Json::Value(stringUtils::escapeHtmlStuff(jaspNativeToUtf8(obj[row])));	}
-
-#define TO_INFINITY_AND_BEYOND																					\
-{																												\
-	double val = static_cast<double>(obj[row]);																	\
-	return	R_IsNA(val) ? "" :																					\
-				R_IsNaN(val) ? "NaN" :																			\
-					val == std::numeric_limits<double>::infinity() ? "\u221E" :									\
-						val == -1 * std::numeric_limits<double>::infinity() ? "-\u221E"  :						\
-							Json::Value((double)(obj[row]));													\
-}
-
-template<> inline Json::Value jaspJson::RVectorEntry_to_JsonValue<REALSXP>(Rcpp::Vector<REALSXP> obj, int row)				TO_INFINITY_AND_BEYOND
-template<> inline Json::Value jaspJson::RMatrixColumnEntry_to_JsonValue<REALSXP>(Rcpp::MatrixColumn<REALSXP> obj, int row)	TO_INFINITY_AND_BEYOND
-
 
 class jaspJson_Interface : public jaspObject_Interface
 {

--- a/src/jaspQmlSource.cpp
+++ b/src/jaspQmlSource.cpp
@@ -3,6 +3,7 @@
 jaspQmlSource::jaspQmlSource(const std::string & sourceID) : jaspJson(), _sourceID(sourceID)
 {
 	_type = jaspObjectType::qmlSource;
+	_escapeHtml = false;
 }
 
 Json::Value jaspQmlSource::dataEntry(std::string & errorMessage) const

--- a/src/jaspTable.cpp
+++ b/src/jaspTable.cpp
@@ -257,7 +257,7 @@ void jaspTable::addRowsFromList(Rcpp::List newData, Rcpp::CharacterVector newRow
 		if(Rcpp::is<Rcpp::List>(rij))
 			 localColNames = extractElementOrColumnNames<Rcpp::List>(Rcpp::as<Rcpp::List>(rij));
 
-		auto jsonRij = jaspJson::RcppVector_to_VectorJson(rij);
+		auto jsonRij = RcppVector_to_VectorJson(rij);
 
 		for(size_t col=0; col<jsonRij.size(); col++)
 			previouslyAddedUnnamedCols	= pushbackToColumnInData(std::vector<Json::Value>({jsonRij[col]}), localColNames.size() > col ? localColNames[col] : "", equalizedColumnsLength, previouslyAddedUnnamedCols);
@@ -287,7 +287,7 @@ void jaspTable::addColumnsFromList(Rcpp::List newData)
 	extractRowNames(newData, true);
 
 	for(int col=0; col<newData.size(); col++)
-		addOrSetColumnInData(jaspJson::RcppVector_to_VectorJson((Rcpp::RObject)newData[col], false), localColNames.size() > col ? localColNames[col] : "");
+		addOrSetColumnInData(RcppVector_to_VectorJson((Rcpp::RObject)newData[col], false), localColNames.size() > col ? localColNames[col] : "");
 }
 
 ///Logically we must assume that each entry in the list is a single element vector
@@ -302,7 +302,7 @@ void jaspTable::setColumnFromList(Rcpp::List column, int colIndex)
 
 	for(int row=0; row<column.size(); row++)
 	{
-		std::vector<Json::Value> jsonVec = jaspJson::RcppVector_to_VectorJson((Rcpp::RObject)column[row], false);
+		std::vector<Json::Value> jsonVec = RcppVector_to_VectorJson((Rcpp::RObject)column[row], false);
 		_data[colIndex].push_back(jsonVec.size() > 0 ? jsonVec[0u] : Json::nullValue);
 	}
 }
@@ -917,12 +917,12 @@ void jaspTable::rectangularDataWithNamesToHtml(std::stringstream & out, std::vec
 
 Json::Value footnotesNamespace::tableFields::rowsToJSON() const
 {
-	return _rows.size() == 0 ? Json::nullValue : jaspJson::SetJson_to_ArrayJson(_rows);
+	return _rows.size() == 0 ? Json::nullValue : jaspObject::SetJson_to_ArrayJson(_rows);
 }
 
 Json::Value footnotesNamespace::tableFields::colsToJSON() const
 {
-	return _cols.size() == 0 ? Json::nullValue : jaspJson::SetJson_to_ArrayJson(_cols);
+	return _cols.size() == 0 ? Json::nullValue : jaspObject::SetJson_to_ArrayJson(_cols);
 }
 
 Json::Value footnotes::convertToJSON() const
@@ -1068,8 +1068,8 @@ void footnotes::convertToJSONOrdered(std::map<std::string, size_t> rowNames, std
 	for(Json::Value & note : notesToOrderMerged)
 		note.removeMember("symbolText");
 
-	fullList	= jaspJson::VectorJson_to_ArrayJson(notesToOrder);
-	mergedList	= jaspJson::VectorJson_to_ArrayJson(notesToOrderMerged);
+	fullList	= jaspObject::VectorJson_to_ArrayJson(notesToOrder);
+	mergedList	= jaspObject::VectorJson_to_ArrayJson(notesToOrderMerged);
 }
 
 void footnotes::convertFromJSON_SetFields(Json::Value footnotes)
@@ -1079,8 +1079,8 @@ void footnotes::convertFromJSON_SetFields(Json::Value footnotes)
 		{
 			const std::string		text	= footnote["text"].asString(),
 									symbol	= footnote["symbol"].asString();
-			std::set<Json::Value>	rows	= jaspJson::ArrayJson_to_SetJson(footnote["rows"]),
-									cols	= jaspJson::ArrayJson_to_SetJson(footnote["cols"]);
+			std::set<Json::Value>	rows	= jaspObject::ArrayJson_to_SetJson(footnote["rows"]),
+									cols	= jaspObject::ArrayJson_to_SetJson(footnote["cols"]);
 
 			_data[text][symbol].insert(tableFields(rows, cols));
 		}
@@ -1107,11 +1107,11 @@ void jaspTable::addFootnote(Rcpp::RObject message, Rcpp::RObject symbol, Rcpp::R
 	
 	std::vector<Json::Value> colNames;
 	if (!col_names.isNULL())
-		colNames = jaspJson::RcppVector_to_VectorJson(col_names, false);
+		colNames = RcppVector_to_VectorJson(col_names, false);
 	
 	std::vector<Json::Value> rowNames;
 	if (!row_names.isNULL())
-		rowNames = jaspJson::RcppVector_to_VectorJson(row_names, false);
+		rowNames = RcppVector_to_VectorJson(row_names, false);
 	
 	_footnotes.insert(strMessage, strSymbol, colNames, rowNames);
 }

--- a/src/jaspTable.h
+++ b/src/jaspTable.h
@@ -190,7 +190,7 @@ protected:
 		extractRowNames(newData, true);
 
 		_data.clear();
-		auto cols = jaspJson::RcppVector_to_VectorJson<RTYPE>(newData);
+		auto cols = RcppVector_to_VectorJson<RTYPE>(newData);
 
 		for(int col=0; col<cols.size(); col++)
 			addOrSetColumnInData(std::vector<Json::Value>({cols[col]}), localColNames.size() > col ? localColNames[col] : "");
@@ -203,7 +203,7 @@ protected:
 
 		_data.clear();
 		for(size_t col=0; col<newData.size(); col++)
-			addOrSetColumnInData(jaspJson::RcppVector_to_VectorJson((Rcpp::RObject)newData[col]), localColNames.size() > col ? localColNames[col] : "");
+			addOrSetColumnInData(RcppVector_to_VectorJson((Rcpp::RObject)newData[col]), localColNames.size() > col ? localColNames[col] : "");
 	}
 
 	template<int RTYPE> void setDataFromMatrix(Rcpp::Matrix<RTYPE> newData)
@@ -211,7 +211,7 @@ protected:
 		std::vector<std::string> localColNames = extractElementOrColumnNames(newData);
 		extractRowNames(newData, true);
 
-		std::vector<std::vector<Json::Value>> jsonMat = jaspJson::RcppMatrix_to_Vector2Json<RTYPE>(newData);
+		std::vector<std::vector<Json::Value>> jsonMat = RcppMatrix_to_Vector2Json<RTYPE>(newData);
 
 		_data.clear();
 		for(size_t col=0; col<jsonMat.size(); col++)
@@ -224,7 +224,7 @@ protected:
 	{
 		setRowNamesWhereApplicable(extractElementOrColumnNames(newData));
 
-		_data.push_back(jaspJson::RcppVector_to_VectorJson<RTYPE>(newData));
+		_data.push_back(RcppVector_to_VectorJson<RTYPE>(newData));
 	}
 
 	template<int RTYPE>	void setColumnFromVector(Rcpp::Vector<RTYPE> newData, size_t col)
@@ -233,7 +233,7 @@ protected:
 
 		if(_data.size() <= col)
 			_data.resize(col+1);
-		_data[col] = jaspJson::RcppVector_to_VectorJson<RTYPE>(newData);
+		_data[col] = RcppVector_to_VectorJson<RTYPE>(newData);
 	}
 
 	void setColumnFromList(Rcpp::List column, int colIndex);
@@ -243,7 +243,7 @@ protected:
 		std::vector<std::string> localColNames = extractElementOrColumnNames(newData);
 		extractRowNames(newData, true);
 
-		std::vector<std::vector<Json::Value>> jsonMat = jaspJson::RcppMatrix_to_Vector2Json<RTYPE>(newData);
+		std::vector<std::vector<Json::Value>> jsonMat = RcppMatrix_to_Vector2Json<RTYPE>(newData);
 
 		for(size_t col=0; col<jsonMat.size(); col++)
 			addOrSetColumnInData(jsonMat[col], localColNames.size() > col ? localColNames[col] : "");
@@ -253,7 +253,7 @@ protected:
 	{
 		std::vector<std::string> localColNames = extractElementOrColumnNames(newData);
 
-		auto row = jaspJson::RcppVector_to_VectorJson<RTYPE>(newData);
+		auto row = RcppVector_to_VectorJson<RTYPE>(newData);
 
 		int equalizedColumnsLength = equalizeColumnsLengths();
 		int previouslyAddedUnnamedCols = 0;
@@ -285,7 +285,7 @@ protected:
 		for(size_t col=0; col<newData.size(); col++)
 		{
 			Rcpp::RObject kolom			= (Rcpp::RObject)newData[col];
-			auto jsonKolom				= jaspJson::RcppVector_to_VectorJson(kolom);
+			auto jsonKolom				= RcppVector_to_VectorJson(kolom);
 			previouslyAddedUnnamedCols	= pushbackToColumnInData(jsonKolom, localColNames.size() > col ? localColNames[col] : "", equalizedColumnsLength, previouslyAddedUnnamedCols);
 		}
 
@@ -302,7 +302,7 @@ protected:
 		for(int row=0; row<newRowNames.size(); row++)
 			_rowNames[row + equalizedColumnsLength] = newRowNames[row];
 
-		auto jsonMatrix = jaspJson::RcppMatrix_to_Vector2Json<RTYPE>(newData);
+		auto jsonMatrix = RcppMatrix_to_Vector2Json<RTYPE>(newData);
 
 		for(int col=0; col<jsonMatrix.size(); col++)
 			previouslyAddedUnnamedCols = pushbackToColumnInData(std::vector<Json::Value>({jsonMatrix[col]}), localColNames.size() > col ? localColNames[col] : "", equalizedColumnsLength, previouslyAddedUnnamedCols);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1763

The jaspQmlSource is derived from JaspJson, that has functions to convert R objects to Json (RVectorEntry_to_JsonValue & RMatrixColumnEntry_to_JsonValue). These functions encode per default Html characters (because the result is send to the Web Browser), but this is not wanted for jaspQmlSource objects. To solve this problem, an extra class property is added _encodeHtml which is set to true per default, but set to false for jaspQmlSource.
Unfortunately these functions that convert R objects to Json value are static, because these functions are directly used in other classes that are not derived from jaspJson. So all these static functions have been moved to jaspObject so that all other objects have access directly to them.